### PR TITLE
Added warning about calling register_tags() when decoding

### DIFF
--- a/src/ur_decodable.rs
+++ b/src/ur_decodable.rs
@@ -7,8 +7,13 @@ use dcbor::CBORTaggedDecodable;
 /// A type that can be decoded from a UR.
 pub trait URDecodable: CBORTaggedDecodable {
     fn from_ur(ur: impl AsRef<UR>) -> Result<Self> where Self: Sized {
-        ur.as_ref().check_type(Self::cbor_tags()[0].name().as_ref().unwrap().clone())?;
-        Self::from_untagged_cbor(ur.as_ref().clone().into())
+        let tag = &Self::cbor_tags()[0];
+        if let Some(name) = tag.name().as_ref() {
+            ur.as_ref().check_type(name.clone())?;
+            Self::from_untagged_cbor(ur.as_ref().clone().into())
+        } else {
+            panic!("CBOR tag {} must have a name. Did you call `register_tags()`?", tag.value());
+        }
     }
 
     fn from_ur_string(ur_string: impl Into<String>) -> Result<Self> where Self: Sized {


### PR DESCRIPTION
I thought it would be useful to have the same warning when decoding as when encoding (added here: ac5ea2245f239c400baa0beb3e75347a33d75ca8)
 